### PR TITLE
Ansible Galaxy role name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ Elasticsearch
 
 |galaxy|
 
-.. |galaxy| image:: https://img.shields.io/ansible/role/24785.svg
-    :target: https://galaxy.ansible.com/tjanez/elasticsearch/
+.. |galaxy| image:: https://img.shields.io/ansible/role/43976.svg
+    :target: https://galaxy.ansible.com/genialis/elasticsearch/
     :alt: Ansible Role
 
 Ansible role to install and configure Elasticsearch 6.x on RHEL/CentOS 7.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  name: elasticsearch
   author: Genialis
   description: >
     Role to install and configure Elasticsearch 6.x on RHEL/CentOS 7.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 galaxy_info:
-  name: elasticsearch
+  role_name: elasticsearch
   author: Genialis
   description: >
     Role to install and configure Elasticsearch 6.x on RHEL/CentOS 7.


### PR DESCRIPTION
Issue:
In Ansible Galaxy, the elasticsearch role is named ansible_elasticsearch_role instead of just elasticsearch.

Changes:
- Update configuration in meta/main.yml.