### PR TITLE
Port to Python3 and Ansible 2.9

### DIFF
--- a/tasks/configure-tuned.yml
+++ b/tasks/configure-tuned.yml
@@ -41,6 +41,6 @@
     dest: "{{ elasticsearch_tuned_profile_custom_conf }}"
     section: sysctl
     option: vm.swappiness
-    value: 1
+    value: "1"
   notify:
     - Restart tuned

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -33,7 +33,7 @@
 - name: Limit swapping to emergency memory situations
   sysctl:
     name: vm.swappiness
-    value: 1
+    value: "1"
     sysctl_file: "{{ elasticsearch_sysctl_file }}"
   when: not elasticsearch_tuned_service_enabled
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -26,8 +26,8 @@
 - name: Remove other version of Elasticsearch
   package: name=elasticsearch state=absent
   when:
-    - not elasticsearch_version_res.stdout | match('package elasticsearch is not installed')
-    - not elasticsearch_version_res.stdout | search('^' + elasticsearch_version)
+    - not elasticsearch_version_res.stdout is match('package elasticsearch is not installed')
+    - not elasticsearch_version_res.stdout is search('^' + elasticsearch_version)
 
 - name: Install Elasticsearch
   package: name=elasticsearch state=present

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -17,7 +17,7 @@
       Elasticsearch process' maximum number of open file descriptors is not set
       high enough (i.e. to more than 64000). For more info, see:
       https://www.elastic.co/guide/en/elasticsearch/guide/current/_file_descriptors_and_mmap.html
-  when: elasticsearch_process_res.json.nodes.values().0.process.max_file_descriptors | int < 64000
+  when: (elasticsearch_process_res.json.nodes.values() | list).0.process.max_file_descriptors | int < 64000
 
 - name: Get value of maximum number of memory map areas for a process
   command: sysctl --values vm.max_map_count
@@ -70,4 +70,4 @@
       Elasticsearch is not using compressed ordinary object pointers. Heap size
       is too large! For more info, see:
       https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html
-  when: elasticsearch_jvm_res.json.nodes.values().0.jvm.using_compressed_ordinary_object_pointers | bool == False
+  when: (elasticsearch_jvm_res.json.nodes.values() | list).0.jvm.using_compressed_ordinary_object_pointers | bool == False


### PR DESCRIPTION
Changes for Python3 compatibility:
- Python3 replaced list with dict_values when accessing dictionary values. This fix will cast dict_values back to list to ensure the first element can be accessed using an index. Changed tasks/validate.yml.

Ansible 2.9 compatibility changes:
- Filters were replaced with jinja tests (Deprecated as of Ansible 2.5)
- When setting string variable with digit, warnings occur in Ansible 2.8+, so the value is put in quotes.